### PR TITLE
Final edit for the lastest version

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "smart-lower-thirds",
   "displayName": "A lightweight lower thirds plugin that works directly inside OBS Studio",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": "MML Tech",
   "website": "https://ko-fi.com/mmltech",
   "email": "contact@obscountdown.com"

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
 #define PLUGIN_NAME "smart-lower-thirds"
-#define PLUGIN_VERSION "2.4.0"
+#define PLUGIN_VERSION "2.5.0"

--- a/src/headers/core.hpp
+++ b/src/headers/core.hpp
@@ -36,6 +36,10 @@ namespace smart_lt {
 
 struct lower_third_cfg {
 	std::string id;
+	// Display-only label for the dock list (does not affect overlay content)
+	std::string label;
+	// Sort key for arranging items in the dock (lower first)
+	int order = 0;
 
 	std::string title;
 	std::string subtitle;
@@ -149,7 +153,6 @@ bool save_visible_json();
 // -------------------------
 bool ensure_output_artifacts_exist();
 bool regenerate_merged_css_js();
-std::string generate_timestamp_html();
 bool rebuild_and_swap();
 
 // Force reload state+visible from disk and rebuild/swap (with notifications)
@@ -163,6 +166,15 @@ std::string target_browser_source_name();
 bool set_target_browser_source_name(const std::string &name);
 bool target_browser_source_exists();
 bool swap_target_browser_source_to_file(const std::string &absoluteHtmlPath);
+
+// Browser source dimensions (persisted in module config)
+int target_browser_width();
+int target_browser_height();
+bool set_target_browser_dimensions(int width, int height);
+
+// Dock behavior (persisted in module config)
+bool dock_exclusive_mode();
+bool set_dock_exclusive_mode(bool enabled);
 
 // -------------------------
 // Paths
@@ -185,5 +197,8 @@ std::string new_id();
 std::string add_default_lower_third();
 std::string clone_lower_third(const std::string &id);
 bool remove_lower_third(const std::string &id);
+
+// Reorder helpers (persist + notify). delta: -1 (up), +1 (down)
+bool move_lower_third(const std::string &id, int delta);
 
 } // namespace smart_lt

--- a/src/headers/dock.hpp
+++ b/src/headers/dock.hpp
@@ -19,6 +19,7 @@ class QShortcut;
 class QEvent;
 class QTimer;
 class QComboBox;
+class QSpinBox;
 
 namespace smart_lt {
 struct core_event; // provided by core (event bus)
@@ -33,6 +34,8 @@ struct LowerThirdRowUi {
 	QLabel *subLbl = nullptr;
 	QLabel *thumbnailLbl = nullptr;
 	QCheckBox *visibleCheck = nullptr;
+	QPushButton *upBtn = nullptr;
+	QPushButton *downBtn = nullptr;
 	QPushButton *cloneBtn = nullptr;
 	QPushButton *settingsBtn = nullptr;
 	QPushButton *removeBtn = nullptr;
@@ -76,6 +79,8 @@ private:
 	// NEW: combo-box workflow
 	void populateBrowserSources(bool keepSelection = true);
 	void onBrowserSourceChanged(int index);
+	void onBrowserSizeChanged();
+	void onExclusiveModeChanged(int state);
 
 	// NEW: core event bus sync (bidirectional with websocket)
 	void onCoreEvent(const smart_lt::core_event &ev);
@@ -92,6 +97,17 @@ private:
 	// Browser Source selector row
 	QComboBox *browserSourceCombo = nullptr;
 	QPushButton *refreshSourcesBtn = nullptr;
+
+	// Browser Source sizing row
+	QSpinBox *browserWidthSpin = nullptr;
+	QSpinBox *browserHeightSpin = nullptr;
+	QPushButton *applyBrowserSizeBtn = nullptr;
+
+	// Dock behavior
+	QCheckBox *exclusiveModeCheck = nullptr;
+
+	// Footer tools
+	QPushButton *infoBtn = nullptr;
 
 	// Add
 	QPushButton *addBtn = nullptr;

--- a/src/headers/settings.hpp
+++ b/src/headers/settings.hpp
@@ -175,6 +175,7 @@ public:
 private slots:
 	void onSaveAndApply();
 	void onBrowseProfilePicture();
+	void onDeleteProfilePicture();
 	void onPickBgColor();
 	void onPickTextColor();
 
@@ -201,10 +202,12 @@ private:
 	QString pendingProfilePicturePath;
 
 	QLineEdit *titleEdit = nullptr;
+	QLineEdit *labelEdit = nullptr;
 	QLineEdit *subtitleEdit = nullptr;
 
 	QLineEdit *profilePictureEdit = nullptr;
 	QPushButton *browseProfilePictureBtn = nullptr;
+	QPushButton *deleteProfilePictureBtn = nullptr;
 
 	QComboBox *animInCombo = nullptr;
 	QComboBox *animOutCombo = nullptr;


### PR DESCRIPTION
✨ New Features
- Custom Dock Labels: Added a new "Label" field in the Settings dialog. You can now name your Lower Thirds (LTs) specifically for the dock display without affecting the underlying data name.
- Radio Mode (Auto-Exclusive Switching): Added a new checkbox in the dock. When enabled, activating a Lower Third will automatically deactivate any other active LTs, ensuring only one is on-screen at a time.
- Dynamic Browser Source Scaling: Added width and height settings directly to the dock. You can now adjust the dimensions of the browser source on the fly instead of relying on hardcoded values.
- LT Reordering: Added manual controls (Up/Down) to the Lower Thirds list. You can now organize the order of your LTs to match your workflow, similar to how OBS Sources are managed.

🔧 Improvements & Fixes
- Added a Delete button next to the image browse option.
- Implemented a safety confirmation dialog to prevent accidental deletion.
- The system now physically deletes the image file from storage and clears the profile string when confirmed.